### PR TITLE
Make classes mockable.

### DIFF
--- a/src/Asset/Api/ChannelsApi.php
+++ b/src/Asset/Api/ChannelsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class ChannelsApi
+class ChannelsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class ChannelsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/EmailTemplatesApi.php
+++ b/src/Asset/Api/EmailTemplatesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class EmailTemplatesApi
+class EmailTemplatesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class EmailTemplatesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/EmailsApi.php
+++ b/src/Asset/Api/EmailsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class EmailsApi
+class EmailsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class EmailsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/FileContentsApi.php
+++ b/src/Asset/Api/FileContentsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class FileContentsApi
+class FileContentsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class FileContentsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/FilesApi.php
+++ b/src/Asset/Api/FilesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class FilesApi
+class FilesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class FilesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/FoldersApi.php
+++ b/src/Asset/Api/FoldersApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class FoldersApi
+class FoldersApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class FoldersApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/FormFieldsApi.php
+++ b/src/Asset/Api/FormFieldsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class FormFieldsApi
+class FormFieldsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class FormFieldsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/FormsApi.php
+++ b/src/Asset/Api/FormsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class FormsApi
+class FormsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class FormsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/LandingPageContentApi.php
+++ b/src/Asset/Api/LandingPageContentApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class LandingPageContentApi
+class LandingPageContentApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class LandingPageContentApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/LandingPageRedirectRulesApi.php
+++ b/src/Asset/Api/LandingPageRedirectRulesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class LandingPageRedirectRulesApi
+class LandingPageRedirectRulesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class LandingPageRedirectRulesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/LandingPageTemplatesApi.php
+++ b/src/Asset/Api/LandingPageTemplatesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class LandingPageTemplatesApi
+class LandingPageTemplatesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class LandingPageTemplatesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/LandingPagesApi.php
+++ b/src/Asset/Api/LandingPagesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class LandingPagesApi
+class LandingPagesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class LandingPagesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/ProgramsApi.php
+++ b/src/Asset/Api/ProgramsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class ProgramsApi
+class ProgramsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class ProgramsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/SegmentsApi.php
+++ b/src/Asset/Api/SegmentsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class SegmentsApi
+class SegmentsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class SegmentsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/SmartCampaignsApi.php
+++ b/src/Asset/Api/SmartCampaignsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class SmartCampaignsApi
+class SmartCampaignsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class SmartCampaignsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/SmartListsApi.php
+++ b/src/Asset/Api/SmartListsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class SmartListsApi
+class SmartListsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class SmartListsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/SnippetsApi.php
+++ b/src/Asset/Api/SnippetsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class SnippetsApi
+class SnippetsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class SnippetsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/StaticListsApi.php
+++ b/src/Asset/Api/StaticListsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class StaticListsApi
+class StaticListsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class StaticListsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/TagsApi.php
+++ b/src/Asset/Api/TagsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class TagsApi
+class TagsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class TagsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Asset/Api/TokensApi.php
+++ b/src/Asset/Api/TokensApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Asset\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class TokensApi
+class TokensApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class TokensApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/FailedResponse.php
+++ b/src/FailedResponse.php
@@ -23,7 +23,7 @@ use Neclimdul\OpenapiPhp\Helper\Response\ApiResponseInterface;
 /**
  * @template ResultType of CompanyResponse|CustomActivity|FormResponse|NamedAccount|NamedAccountList|ProgramMemberDataResponse|ProgramMemberDeleteResponse|ProgramMemberStatusResponse|SalesPerson
  */
-readonly class FailedResponse
+class FailedResponse
 {
     /**
      * @param ModelInterface $result
@@ -31,9 +31,9 @@ readonly class FailedResponse
      * @param array<\NecLimDul\MarketoRest\Lead\Model\Error|\NecLimDul\MarketoRest\Asset\Model\Error> $errors
      */
     public function __construct(
-        public ModelInterface $result,
-        public string $message = '',
-        public array $errors = [],
+        public readonly ModelInterface $result,
+        public readonly string $message = '',
+        public readonly array $errors = [],
     ) {
     }
 

--- a/src/Lead/Api/ActivitiesApi.php
+++ b/src/Lead/Api/ActivitiesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class ActivitiesApi
+class ActivitiesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class ActivitiesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/BulkExportActivitiesApi.php
+++ b/src/Lead/Api/BulkExportActivitiesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class BulkExportActivitiesApi
+class BulkExportActivitiesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class BulkExportActivitiesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/BulkExportCustomObjectsApi.php
+++ b/src/Lead/Api/BulkExportCustomObjectsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class BulkExportCustomObjectsApi
+class BulkExportCustomObjectsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class BulkExportCustomObjectsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/BulkExportLeadsApi.php
+++ b/src/Lead/Api/BulkExportLeadsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class BulkExportLeadsApi
+class BulkExportLeadsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class BulkExportLeadsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/BulkExportProgramMembersApi.php
+++ b/src/Lead/Api/BulkExportProgramMembersApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class BulkExportProgramMembersApi
+class BulkExportProgramMembersApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class BulkExportProgramMembersApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/BulkImportCustomObjectsApi.php
+++ b/src/Lead/Api/BulkImportCustomObjectsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class BulkImportCustomObjectsApi
+class BulkImportCustomObjectsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class BulkImportCustomObjectsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/BulkImportLeadsApi.php
+++ b/src/Lead/Api/BulkImportLeadsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class BulkImportLeadsApi
+class BulkImportLeadsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class BulkImportLeadsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/BulkImportProgramMembersApi.php
+++ b/src/Lead/Api/BulkImportProgramMembersApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class BulkImportProgramMembersApi
+class BulkImportProgramMembersApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class BulkImportProgramMembersApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/CampaignsApi.php
+++ b/src/Lead/Api/CampaignsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class CampaignsApi
+class CampaignsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class CampaignsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/CompaniesApi.php
+++ b/src/Lead/Api/CompaniesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class CompaniesApi
+class CompaniesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class CompaniesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/CustomObjectsApi.php
+++ b/src/Lead/Api/CustomObjectsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class CustomObjectsApi
+class CustomObjectsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class CustomObjectsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/LeadsApi.php
+++ b/src/Lead/Api/LeadsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class LeadsApi
+class LeadsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class LeadsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/NamedAccountListsApi.php
+++ b/src/Lead/Api/NamedAccountListsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class NamedAccountListsApi
+class NamedAccountListsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class NamedAccountListsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/NamedAccountsApi.php
+++ b/src/Lead/Api/NamedAccountsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class NamedAccountsApi
+class NamedAccountsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class NamedAccountsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/OpportunitiesApi.php
+++ b/src/Lead/Api/OpportunitiesApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class OpportunitiesApi
+class OpportunitiesApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class OpportunitiesApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/ProgramMembersApi.php
+++ b/src/Lead/Api/ProgramMembersApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class ProgramMembersApi
+class ProgramMembersApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class ProgramMembersApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/SalesPersonsApi.php
+++ b/src/Lead/Api/SalesPersonsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class SalesPersonsApi
+class SalesPersonsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class SalesPersonsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/StaticListsApi.php
+++ b/src/Lead/Api/StaticListsApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class StaticListsApi
+class StaticListsApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class StaticListsApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 

--- a/src/Lead/Api/UsageApi.php
+++ b/src/Lead/Api/UsageApi.php
@@ -40,7 +40,7 @@ use NecLimDul\MarketoRest\Lead\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-readonly class UsageApi
+class UsageApi
 {
     /**
      * @param Configuration $config
@@ -53,10 +53,10 @@ readonly class UsageApi
      *   Serialization service.
      */
     public function __construct(
-        public Configuration $config,
-        private Client $client,
-        private RequestFactory $requestFactory,
-        private SerializerInterface $serializer,
+        public readonly Configuration $config,
+        private readonly Client $client,
+        private readonly RequestFactory $requestFactory,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 


### PR DESCRIPTION
Readonly class was introduced in PHP 8.2 as a convenience shorthand — it makes every property in the class implicitly readonly without having to write readonly on each one individually. The intent in this library was just to express "these API objects are immutable once constructed."

The problem is a PHP 8.3.30 + Prophecy incompatibility. When Prophecy mocks a class, it generates a subclass at runtime via eval(). That generated subclass adds its own property $objectProphecyClosure (which it needs internally). But PHP enforces that any class extending a readonly class must itself be readonly, and all properties in a readonly class must have an explicit type declaration. Prophecy's generated $objectProphecyClosure has no type, so PHP rejects it with a fatal error.